### PR TITLE
fixed files with bom + enclosures around first col in header line

### DIFF
--- a/tests/ByteOrderMarkTest.php
+++ b/tests/ByteOrderMarkTest.php
@@ -9,9 +9,19 @@ use DavidBadura\SimpleCsv\CsvParser;
 
 class ByteOrderMarkTest extends \PHPUnit_Framework_TestCase
 {
-    public function testBom()
+    public static function testBomProvider()
     {
-        $file = __DIR__ . '/_files/byte-order-mark-test.csv';
+        return array(
+            array(__DIR__ . '/_files/byte-order-mark-test.csv'),
+            array(__DIR__ . '/_files/byte-order-mark-test-with-enclosure.csv'),
+        );
+    }
+
+    /**
+     * @dataProvider testBomProvider
+     */
+    public function testBom($file)
+    {
         foreach (new CsvParser($file, ';') as $row) {
             $this->assertEquals($row['col-with-bom'], 'data-col-with-bom');
         }

--- a/tests/_files/byte-order-mark-test-with-enclosure.csv
+++ b/tests/_files/byte-order-mark-test-with-enclosure.csv
@@ -1,0 +1,2 @@
+﻿"col-with-bom";"second-col"
+data-col-with-bom;"data-second-col"


### PR DESCRIPTION
In addition to #5 - when a file inlcuding a BOM has enclosures around the first column, those enclosure must be stripped manually.